### PR TITLE
Add support for browsers with out IntersectionObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ npm -i -S @power-elements/lazy-image
 <lazy-image src="/image.jpg" alt="Lazy Image"></lazy-image>
 ```
 
-### 'IntersectionObserver' in window
+### Browser support
 `lazy-image` manages the loading of your images via an Intersection Observer. In browsers where an Intersection Observer is not present, your images will be loaded immediately much like standard `<img/>` elements. Conditionally delivering the [IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill) along with your `lazy-image`s to your users will ensure that all users experience the benefits of loading images lazily. Stay lazy, friend!

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ npm -i -S @power-elements/lazy-image
 ```html
 <lazy-image src="/image.jpg" alt="Lazy Image"></lazy-image>
 ```
+
+### 'IntersectionObserver' in window
+`lazy-image` manages the loading of your images via an Intersection Observer. In browsers where an Intersection Observer is not present, your images will be loaded immediately much like standard `<img/>` elements. Conditionally delivering the [IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill) along with your `lazy-image`s to your users will ensure that all users experience the benefits of loading images lazily. Stay lazy, friend!

--- a/lazy-image.js
+++ b/lazy-image.js
@@ -200,9 +200,11 @@ class LazyImage extends HTMLElement {
 
   /** @protected */
   connectedCallback() {
-    this.initIntersectionObserver(this);
     this.attachShadow({mode: 'open'})
       .appendChild(getTemplate(this).content.cloneNode(true))
+    ('IntersectionObserver' in window)
+      ? this.initIntersectionObserver(this)
+      : this.setIntersecting(true)
 
     this.placeholder = this.getAttribute('placeholder')
   }

--- a/lazy-image.js
+++ b/lazy-image.js
@@ -201,7 +201,7 @@ class LazyImage extends HTMLElement {
   /** @protected */
   connectedCallback() {
     this.attachShadow({mode: 'open'})
-      .appendChild(getTemplate(this).content.cloneNode(true))
+      .appendChild(getTemplate(this).content.cloneNode(true));
     ('IntersectionObserver' in window)
       ? this.initIntersectionObserver(this)
       : this.setIntersecting(true)

--- a/test/lazy-image.test.html
+++ b/test/lazy-image.test.html
@@ -42,7 +42,7 @@
       });
 
       test('does not set img src', function() {
-        assert.notOk(lazy.__img.src);
+        assert.notEqual(lazy.__img.src, 'http://placekitten.com/400/300');
       });
     });
 

--- a/test/lazy-image.test.html
+++ b/test/lazy-image.test.html
@@ -46,6 +46,22 @@
       });
     });
 
+    suite('"IntersectionObserver" not in window', function() {
+      let hasNative = ('IntersectionObserver' in window);
+      let IntersectionObserver;
+      if (hasNative) {
+        IntersectionObserver = window.IntersectionObserver;
+        delete window.IntersectionObserver;
+      }
+      const lazy = fixture('src-attr');
+      test('sets img src immediately', function() {
+        assert.ok(lazy.__img.src);
+      });
+      if (hasNative) {
+        window.IntersectionObserver = IntersectionObserver;
+      }
+    });
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
fixes https://github.com/bennypowers/lazy-image/issues/3

- add fallback support for browsers without IntersectionObserver
- update README.md with rough "polyfill from the outside" policy
- add test for `!('IntersectionObserver' in window)`