### PR TITLE
Dispose observer once image loaded

### DIFF
--- a/lazy-image.js
+++ b/lazy-image.js
@@ -130,6 +130,7 @@ class LazyImage extends HTMLElement {
    */
   loadImage() {
     this.setAttribute('intersecting', '');
+    this.disconnectObserver();
     this.shadowImage.src = this.src;
   }
 


### PR DESCRIPTION
No need for the observer after loading, CPU waste.